### PR TITLE
Preserve grouping

### DIFF
--- a/q2_ps_plot/actions/scatter.py
+++ b/q2_ps_plot/actions/scatter.py
@@ -42,13 +42,14 @@ def _make_pairs_list(column, type):
 def repScatters(
     output_dir: str,
     source: qiime2.CategoricalMetadataColumn = None,
+    user_spec_pairs: list = None,
     pn_filepath: str = None,
     plot_log: bool = False,
     zscore: pd.DataFrame = None,
     col_sum: pd.DataFrame = None,
     facet_charts: bool = False,
-    xy_threshold: int = None)->None:
-
+    xy_threshold: int = None
+) -> None:
     # check wether zscore matrix or colsum matrix was provided
     if zscore is not None:
         data = zscore.transpose()
@@ -68,7 +69,9 @@ def repScatters(
         scatterDict[nm]
 
     # call function to collect samples pairs
-    if source:
+    if user_spec_pairs:
+        pairs = [tuple(tuple(user_spec_pairs[i:i+2]) for i in range(0, len(user_spec_pairs), 2))]
+    elif source:
         pairs = _make_pairs_list(source, "sourceCol")
     elif pn_filepath:
         pairs = _make_pairs_list(pn_filepath, "pnFile")
@@ -80,7 +83,7 @@ def repScatters(
     for lst in pairs:
         for tpl in lst:
 
-            #set x and y values from the dataframe
+            # set x and y values from the dataframe
             if type(tpl) is tuple:
                 samp = '~'.join(tpl)
                 samples.append(samp)

--- a/q2_ps_plot/actions/scatter_tsv.py
+++ b/q2_ps_plot/actions/scatter_tsv.py
@@ -3,6 +3,7 @@ from q2_pepsirf.format_types import PepsirfContingencyTSVFormat, MutantReference
 def repScatters_tsv(
     ctx,
     source = None,
+    user_spec_pairs=None,
     pn_filepath= None,
     plot_log= False,
     zscore_filepath = None,
@@ -30,6 +31,7 @@ def repScatters_tsv(
 
     repScatters_vis, = repScatters(
         source = source,
+        user_spec_pairs = user_spec_pairs,
         pn_filepath = pn_filepath,
         plot_log = plot_log,
         zscore = zscore,

--- a/q2_ps_plot/plugin_setup.py
+++ b/q2_ps_plot/plugin_setup.py
@@ -140,6 +140,7 @@ plugin.visualizers.register_function(
 
 repScatters_parameters = {
         'source': MetadataColumn[Categorical],
+        'user_spec_pairs': List[Str],
         'plot_log': Bool,
         'facet_charts': Bool,
         'pn_filepath': Str,
@@ -149,6 +150,7 @@ repScatters_parameters = {
 repScatters_parameter_descriptions = {
         'source': "Metadata file containing all sample names and their source groups. "
             "Used to create pairs tsv to run pepsirf enrich module.",
+        'user_spec_pairs': "!!!Write a description!!!",
         'plot_log': "Use if you want axes to be shown on a log-scale.",
         'facet_charts': "Allows for view of all tables on one page instead of the "
                     "available dropdown menu.",


### PR DESCRIPTION
This commit corresponds to the commit in QC module which attempts to honor user specified replicate groups. This commit adds the necessary parameter "user_spec_pairs" to the "repScatter" and "repScatter_tsv" functions using the Qiime2 pipeline. "user_spec_pairs" is them used to form a list of pairs called "pairs" which is formatted into a list of a tuple of tuples that represent the pairs of replicates to consider.